### PR TITLE
fix: resolve ZeroDivisionError and NameError in OpenAICloseSetClsEvaluator.print_results

### DIFF
--- a/pointllm/eval/evaluator.py
+++ b/pointllm/eval/evaluator.py
@@ -399,7 +399,7 @@ class OpenAICloseSetClsEvaluator(OpenAIOpenFreeFormClsEvaluator):
                 # * not valid range
                 cls_result = -1
         except ValueError:
-            print(f"Error: unale to parse {gpt_response}.")
+            print(f"Error: unable to parse {gpt_response}.")
             cls_result = -1
 
         if cls_result == -1:
@@ -562,10 +562,10 @@ class OpenAICloseSetClsEvaluator(OpenAIOpenFreeFormClsEvaluator):
         print('-' * 80)
         if self.total_predictions - self.invalid_responses == 0:
             accuracy = 0 # * no results and get error
+            clean_accuracy = 0
         else:
             accuracy = self.correct_predictions / self.total_predictions * 100
             clean_accuracy = (self.correct_predictions - self.invalid_correct_predictions) / (self.total_predictions - self.invalid_responses) * 100
-        accuracy = self.correct_predictions / self.total_predictions * 100
         print("Results:")
         print(f"Accuracy: {accuracy:.2f}%")
         print(f"Clean Accuracy: {clean_accuracy:.2f}%",)
@@ -638,7 +638,7 @@ class OpenAIObjectCaptioningEvaluator(OpenAIOpenFreeFormClsEvaluator):
                 # * not valid range
                 gpt_score = -1
         except ValueError:
-            print(f"Error: unale to parse {gpt_response}.")
+            print(f"Error: unable to parse {gpt_response}.")
             gpt_score = -1
 
         if gpt_score == -1:


### PR DESCRIPTION
## Problem

`OpenAICloseSetClsEvaluator.print_results()` in `pointllm/eval/evaluator.py` contains two bugs that cause crashes when `total_predictions == 0` (e.g. evaluation on an empty result set):

1. **ZeroDivisionError**: A stray `accuracy = self.correct_predictions / self.total_predictions * 100` line was placed *outside* the `if/else` guard block (line 568 before this fix). This overwrites the `accuracy = 0` safety value set in the `if` branch, then immediately raises `ZeroDivisionError` when `total_predictions == 0`.

2. **NameError**: `clean_accuracy` was only assigned inside the `else` branch. When the `if` branch executes (i.e. `total_predictions - invalid_responses == 0`), `clean_accuracy` was never defined, causing `NameError: name 'clean_accuracy' is not defined` on the subsequent `print` call.

Note: the companion method `save_results()` already handles both variables correctly in both branches — this fix brings `print_results()` into alignment with that implementation.

## Solution

- Remove the duplicated `accuracy` assignment outside the `if/else` block.
- Initialize `clean_accuracy = 0` in the `if` branch, matching the pattern already used in `save_results()`.

## Additional fixes

- Fix two typos: `"unale to parse"` → `"unable to parse"` (in `OpenAICloseSetClsEvaluator.parse_gpt_response_evaluate` and `OpenAIObjectCaptioningEvaluator.parse_gpt_response_evaluate`).

## Testing

Manually verified both bugs with a minimal reproducer:

```python
# Before fix: raises ZeroDivisionError when total_predictions == 0
# Before fix: raises NameError for clean_accuracy when if-branch executes
# After fix: returns accuracy=0, clean_accuracy=0 safely
```